### PR TITLE
Update package to use prebuilt leveldown

### DIFF
--- a/level.js
+++ b/level.js
@@ -1,1 +1,1 @@
-module.exports = require('level-packager')(require('leveldown'))
+module.exports = require('level-packager')(require('leveldown-prebuilt'))

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     ]
   , "main"            : "level.js"
   , "dependencies"    : {
-        "leveldown"       : "~0.10.0"
-      , "level-packager"  : "~0.18.0"
+        "leveldown-prebuilt": "~0.10.2"
+      , "level-packager"    : "~0.18.0"
     }
   , "devDependencies" : {
         "tape"            : "*"


### PR DESCRIPTION
Using `leveldown-prebuilt` would enable easy use on Windows systems which do not have a suitable compiler suite installed.
