### PR TITLE
bump leveldown to ~1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     ]
   , "main"            : "level.js"
   , "dependencies"    : {
-        "leveldown"       : "~0.10.0"
+        "leveldown"       : "~1.0"
       , "level-packager"  : "~0.18.0"
     }
   , "devDependencies" : {


### PR DESCRIPTION
if you bump the version, node-0.11.x users can install...

should be 1.0 anyway...

cheers
