### PR TITLE
bump leveldown dependency to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     ]
   , "main"            : "level.js"
   , "dependencies"    : {
-        "leveldown"       : "~0.10.0"
+        "leveldown"       : "~1.0.0"
       , "level-packager"  : "~0.18.0"
     }
   , "devDependencies" : {


### PR DESCRIPTION
leveldown pre-1.0.0 seems to [have](http://stackoverflow.com/questions/27303442/node-js-strange-behaviour-perhaps-module-memory-limit-on-os-x) [issues](https://github.com/ethereum/node-ethereum/issues/6) on OS X.
