### PR TITLE
deps: bump leveldown version for iojs compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     ]
   , "main"            : "level.js"
   , "dependencies"    : {
-        "leveldown"       : "~0.10.0"
+        "leveldown"       : "~1.0.1"
       , "level-packager"  : "~0.18.0"
     }
   , "devDependencies" : {


### PR DESCRIPTION
This bumps the `leveldown` version to ensure `io.js` compatibility. Might warrant a major version bump since `leveldown` also went post `1.0.0`. Thanks!

 Ps. By merging this you help in bringing [`clocker`](https://github.com/substack/clocker) to `io.js`!