### PR TITLE
Update to leveldown@~1.3.0 & level-packager@~1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "main": "level.js",
   "dependencies": {
     "level-packager": "~1.0.0",
-    "leveldown": "~1.2.2"
+    "leveldown": "~1.3.0"
   },
   "devDependencies": {
     "tape": "~4.0.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "main": "level.js",
   "dependencies": {
-    "level-packager": "~1.0.0",
+    "level-packager": "~1.1.0",
     "leveldown": "~1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
leveldown 1.2.2 produced a warning during build, doesn't seem to be a problem with latest leveldown.

```
../src/database.cc:552:11: warning: 'FatalException' is deprecated: Use FatalException(isolate, ...) [-Wdeprecated-declarations]
    node::FatalException(try_catch);
          ^
```