### PR TITLE
Add appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: "{build}"
+build: off
+skip_tags: true
+
+environment:
+  matrix:
+    - nodejs_version: "6"
+    - nodejs_version: "8"
+    - nodejs_version: "9"
+    - nodejs_version: "10"
+
+platform:
+  - x86
+  - x64
+
+install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - set PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
+  - npm i
+
+test_script:
+  - npm test

--- a/package.json
+++ b/package.json
@@ -39,10 +39,11 @@
   },
   "devDependencies": {
     "standard": "^11.0.0",
-    "tape": "^4.2.2"
+    "tape": "^4.2.2",
+    "verify-travis-appveyor": "^3.0.0"
   },
   "scripts": {
-    "test": "standard && node test.js",
+    "test": "standard && node test.js && verify-travis-appveyor",
     "postinstall": "opencollective-postinstall || exit 0"
   },
   "engines": {


### PR DESCRIPTION
Closes https://github.com/Level/level/issues/109

Note: I added `verify-travis-appveyor` at the end of tests. We can then tweak `verify-travis-appveyor` to give a nice output when e.g. warning about EOL versions, which would never been seen if executed as the first test.