### PR TITLE
Temporarily skip hallmark test because it breaks citgm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "level.js",
   "scripts": {
-    "test": "standard && hallmark && nyc node test.js && verify-travis-appveyor",
+    "test": "standard && nyc node test.js && verify-travis-appveyor",
     "test-browser-local": "airtap --local test-browser.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "postinstall": "opencollective-postinstall || exit 0",


### PR DESCRIPTION
Fixes one half of https://github.com/nodejs/citgm/issues/694.

The problem is that CITGM doesn't clone the repo, so hallmark (more specifically, [remark-git-contributors](https://github.com/remarkjs/remark-git-contributors)) throws. Later on this should fixed in hallmark.

FYI @ralphtheninja 