### PR TITLE
chore: update level-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "browser": "browser.js",
   "dependencies": {
-    "level-js": "^5.0.0",
+    "level-js": "^6.0.0",
     "level-packager": "^5.1.0",
     "leveldown": "^5.4.0"
   },


### PR DESCRIPTION
Follows on from https://github.com/Level/level-js/pull/210 and updates level-js to the new version.

BREAKING CHANGE: the underlying [buffer](https://www.npmjs.com/package/buffer) browser polyfill has dropped support for ie11/safari < 10