### PR TITLE
chore: update level-packager and leveldown

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "browser": "browser.js",
   "dependencies": {
     "level-js": "^6.0.0",
-    "level-packager": "^5.1.0",
-    "leveldown": "^5.4.0"
+    "level-packager": "^6.0.0",
+    "leveldown": "^6.0.0"
   },
   "devDependencies": {
     "airtap": "^4.0.1",
@@ -27,9 +27,9 @@
     "level-community": "^3.0.0",
     "nyc": "^15.0.0",
     "pinkie": "^2.0.4",
-    "standard": "^15.0.0",
+    "standard": "^16.0.3",
     "tape": "^5.0.1",
-    "uuid": "^3.4.0",
+    "uuid": "^8.3.2",
     "verify-travis-appveyor": "^3.0.0"
   },
   "funding": {

--- a/test-browser.js
+++ b/test-browser.js
@@ -5,9 +5,9 @@ if (typeof Promise !== 'function') {
   global.Promise = require('pinkie')
 }
 
-var test = require('tape')
-var uuid = require('uuid/v4')
-var level = require('.')
+const test = require('tape')
+const uuid = require('uuid/v4')
+const level = require('.')
 
 require('level-packager/abstract/base-test')(test, level)
 require('level-packager/abstract/db-values-test')(test, level)
@@ -19,7 +19,7 @@ function factory (opts) {
 test('level put', function (t) {
   t.plan(4)
 
-  var db = factory()
+  const db = factory()
 
   db.put('name', 'level', function (err) {
     t.ifError(err, 'no put error')
@@ -38,8 +38,8 @@ test('level put', function (t) {
 test('level Buffer value', function (t) {
   t.plan(5)
 
-  var db = factory({ valueEncoding: 'binary' })
-  var buf = Buffer.from('00ff', 'hex')
+  const db = factory({ valueEncoding: 'binary' })
+  const buf = Buffer.from('00ff', 'hex')
 
   db.put('binary', buf, function (err) {
     t.ifError(err, 'no put error')
@@ -57,8 +57,8 @@ test('level Buffer value', function (t) {
 })
 
 test('level Buffer key', function (t) {
-  var db = factory({ keyEncoding: 'binary' })
-  var key = Buffer.from('00ff', 'hex')
+  const db = factory({ keyEncoding: 'binary' })
+  const key = Buffer.from('00ff', 'hex')
 
   if (!db.supports.bufferKeys) {
     t.pass('Environment does not support buffer keys')


### PR DESCRIPTION
Updates dependencies to the latest versions and fixes linting errors flagged by the new version of standard.