### PR TITLE
README: Add community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Coverage](https://img.shields.io/codecov/c/github/Level/level?label=\&logo=codecov\&logoColor=fff)](https://codecov.io/gh/Level/level)
 [![Standard](https://img.shields.io/badge/standard-informational?logo=javascript\&logoColor=fff)](https://standardjs.com)
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
+[![Community](https://img.shields.io/badge/community-join-%2370B99E?logo=github)](https://github.com/Level/community/issues)
 [![Donate](https://img.shields.io/badge/donate-orange?logo=open-collective\&logoColor=fff)](https://opencollective.com/level)
 
 ## Table of Contents


### PR DESCRIPTION
Adds a community badge in the README that links to https://github.com/Level/community/issues.

<img width="93" alt="image" src="https://user-images.githubusercontent.com/750276/226191156-8dc983ae-51c7-4202-8d7b-9e9cf8ab6174.png">
