### PR TITLE
Explicitly depend on abstract-level for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "browser": "browser.js",
   "dependencies": {
+    "abstract-level": "^1.0.4",
     "browser-level": "^1.0.1",
     "classic-level": "^1.2.0"
   },


### PR DESCRIPTION
When using `pnpm` as package manager, and disabled dependencies hoist, `level` will miss the type declare of `abstract-level`

This will cause `db.close` missing, because typescript cannot resolve the `abstract-level`.