### PR TITLE
Fix Playwright CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         run: npm install
       - name: Install Playwright
         if: matrix.node == 16
-        run: npx playwright install-deps
+        run: npx playwright install --with-deps
       - name: Test
         run: npm test
       - name: Test browsers


### PR DESCRIPTION
It's now required to run `playwright install` to download browsers, and the `install-deps` and `install`  commands can be combined as `install --with-deps`. See https://playwright.dev/docs/browsers.